### PR TITLE
Fix PutDeployResult instantiation and CLTypeSerializer string handling

### DIFF
--- a/src/Rpc/ResultTypes/PutDeployResult.php
+++ b/src/Rpc/ResultTypes/PutDeployResult.php
@@ -8,7 +8,7 @@ class PutDeployResult extends AbstractResult
 
     public static function fromJSON(array $json): self
     {
-        return self($json, $json['deploy_hash']);
+        return new self($json, $json['deploy_hash']);
     }
 
     public function __construct(array $rawJSON, string $deployHash)

--- a/src/Types/Serializer/CLTypeSerializer.php
+++ b/src/Types/Serializer/CLTypeSerializer.php
@@ -25,11 +25,17 @@ class CLTypeSerializer extends JsonSerializer
     }
 
     /**
+     * @param array|string $json
      * @throws \Exception
      */
-    public static function fromJson(array $json): CLType
+    public static function fromJson($json): CLType
     {
         $classPrefix = 'Casper\Types\CLValue\CLType\CL';
+
+        if (is_string($json)) {
+            $clTypeClass = $classPrefix . $json . 'Type';
+            return new $clTypeClass();
+        }
 
         if (ArrayUtil::isMap($json)) {
             $typeName = array_key_first($json);


### PR DESCRIPTION
* Resolves: #30

### Summary

- fix PutDeployResult::fromJSON to use constructor correctly
- allow CLTypeSerializer::fromJson to accept simple string types (Node v2 compatibility)

### TODO

- [x] Covered in this PR

### Checklist

- [x] Code is properly formatted
- [x] All commits are signed
- [x] Tests included/updated or not needed
- [x] Documentation (manuals or wiki) has been updated or is not required
